### PR TITLE
update remark collector to capture backend machine optimization remarks

### DIFF
--- a/include/OptDebugger/Support.h
+++ b/include/OptDebugger/Support.h
@@ -43,6 +43,7 @@ struct Remark {
   std::string Message;
   std::vector<RemarkArgument> Args;
   std::optional<float> Hotness;
+  bool IsMachine = false;
 
   bool isMissed() const { return Kind == RemarkKind::Missed; }
   bool isApplied() const { return Kind == RemarkKind::Applied; }

--- a/lib/RemarkCollector.cpp
+++ b/lib/RemarkCollector.cpp
@@ -45,11 +45,17 @@ Remark RemarkCollectorHandler::convertRemark(
   Remark R;
 
   unsigned Kind = DI.getKind();
-  if (Kind == llvm::DK_OptimizationRemark)
+  bool IsMachine = (Kind >= llvm::DK_MachineOptimizationRemark &&
+                    Kind <= llvm::DK_MachineOptimizationRemarkAnalysis);
+
+  if (Kind == llvm::DK_OptimizationRemark ||
+      Kind == llvm::DK_MachineOptimizationRemark)
     R.Kind = RemarkKind::Applied;
-  else if (Kind == llvm::DK_OptimizationRemarkMissed)
+  else if (Kind == llvm::DK_OptimizationRemarkMissed ||
+           Kind == llvm::DK_MachineOptimizationRemarkMissed)
     R.Kind = RemarkKind::Missed;
-  else if (Kind == llvm::DK_OptimizationRemarkAnalysis)
+  else if (Kind == llvm::DK_OptimizationRemarkAnalysis ||
+           Kind == llvm::DK_MachineOptimizationRemarkAnalysis)
     R.Kind = RemarkKind::Analysis;
   else if (Kind == llvm::DK_OptimizationRemarkAnalysisAliasing)
     R.Kind = RemarkKind::AnalysisAliasing;
@@ -57,6 +63,8 @@ Remark RemarkCollectorHandler::convertRemark(
     R.Kind = RemarkKind::AnalysisFPCommute;
   else
     R.Kind = RemarkKind::Analysis;
+
+  R.IsMachine = IsMachine;
 
   R.PassName    = DI.getPassName().str();
   R.RemarkName  = DI.getRemarkName().str();
@@ -89,7 +97,10 @@ bool RemarkCollectorHandler::handleDiagnostics(
       Kind == llvm::DK_OptimizationRemarkMissed ||
       Kind == llvm::DK_OptimizationRemarkAnalysis ||
       Kind == llvm::DK_OptimizationRemarkAnalysisAliasing ||
-      Kind == llvm::DK_OptimizationRemarkAnalysisFPCommute;
+      Kind == llvm::DK_OptimizationRemarkAnalysisFPCommute ||
+      Kind == llvm::DK_MachineOptimizationRemark ||
+      Kind == llvm::DK_MachineOptimizationRemarkMissed ||
+      Kind == llvm::DK_MachineOptimizationRemarkAnalysis;
 
   if (!IsOptRemark)
     return false;


### PR DESCRIPTION
just added the basic stuff needed for aion to start picking up backend remarks from llvm.

i updated the remark struct with a machine flag and made sure the collector actually lets those backend diagnostics through now. all ready for the next step where we add the actual backend patterns
hell yeah :)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for detecting and handling machine optimization remarks alongside classic optimization remarks
  * Remarks are now classified by type to enable more granular filtering and analysis

<!-- end of auto-generated comment: release notes by coderabbit.ai -->