### PR TITLE
fix(build): resolve InitLLVM binary mismatch and trim IR text

### DIFF
--- a/lib/IRDiff.cpp
+++ b/lib/IRDiff.cpp
@@ -34,9 +34,13 @@ std::string IRDiffEngine::getInstructionText(const llvm::Instruction &I) {
   I.print(OS);
   OS.flush();
   std::string Result = S;
-  size_t Pos = Result.find_first_not_of(' ');
-  if (Pos != std::string::npos)
-    Result = Result.substr(Pos);
+  size_t Start = Result.find_first_not_of(" \t\r\n");
+  if (Start == std::string::npos)
+    return "";
+  Result = Result.substr(Start);
+  size_t End = Result.find_last_not_of(" \t\r\n");
+  if (End != std::string::npos)
+    Result = Result.substr(0, End + 1);
   return Result;
 }
 

--- a/tools/opt-debugger/main.cpp
+++ b/tools/opt-debugger/main.cpp
@@ -4,6 +4,9 @@
 
 #include "llvm/Support/CommandLine.h"
 #include "llvm/Support/InitLLVM.h"
+#include "llvm/Support/ManagedStatic.h"
+#include "llvm/Support/PrettyStackTrace.h"
+#include "llvm/Support/Signals.h"
 #include "llvm/Support/Process.h"
 #include "llvm/Support/raw_ostream.h"
 #include "llvm/Support/WithColor.h"
@@ -181,7 +184,10 @@ bool hasConflictingOptions() {
 
 // entry point for the opt-debugger executable
 int main(int argc, char **argv) {
-  InitLLVM X(argc, argv);
+  llvm::sys::PrintStackTraceOnErrorSignal(argv[0]);
+  llvm::PrettyStackTraceProgram X(argc, argv);
+  llvm::llvm_shutdown_obj Y;
+
 
   cl::HideUnrelatedOptions(OptDbgCategory);
   cl::ParseCommandLineOptions(


### PR DESCRIPTION
small build fix :/

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced error diagnostics with stack traces during error conditions.
  * Improved text processing robustness for edge cases involving various whitespace characters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->